### PR TITLE
Update url to new repository location

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     author_email='jonathan.buchanan@gmail.com',
     maintainer='Jannis Leidel',
     maintainer_email='jannis@leidel.info',
-    url='http://github.com/jezdez/django-voting/',
+    url='https://github.com/pjdelport/django-voting',
     packages=[
         'voting',
         'voting.migrations',


### PR DESCRIPTION
http://github.com/jezdez/django-voting/ now redirects to https://github.com/pjdelport/django-voting. Update url in setup.py to suit